### PR TITLE
format the basic layout of channel and handlers

### DIFF
--- a/broke/src/main/java/org/syyllab/broke/channel/PipelineInitializer.java
+++ b/broke/src/main/java/org/syyllab/broke/channel/PipelineInitializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.syyllab.broke.channel;
+
+import io.netty.channel.ChannelInitializer;
+
+import io.netty.channel.Channel;
+import org.syyllab.broke.channel.handler.ReadDropHandler;
+
+/**
+ * The PipelineInitializer is a customized ChannelInitializer for desired pipeline of handlers.
+ * <code>
+ *     new PipelineInitializer()
+ * </code>
+ */
+public class PipelineInitializer extends ChannelInitializer<Channel> {
+
+    // TODO: register the handler topologies here.
+    /**
+     * Implement the channel, for the continuous pipeline of handlers.
+     * @param channel
+     * @throws Exception
+     */
+    @Override
+    public void initChannel(Channel channel) throws Exception {
+        channel.pipeline().addLast("ReadDropHandler", new ReadDropHandler());
+    }
+}

--- a/broke/src/main/java/org/syyllab/broke/channel/handler/ReadDropHandler.java
+++ b/broke/src/main/java/org/syyllab/broke/channel/handler/ReadDropHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.syyllab.broke.channel.handler;
+
+import io.netty.buffer.ByteBuf;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * This ReadDropHandler is the example class from netty userguide.
+ * Use this for testing the channel pipeline and server.
+ */
+public class ReadDropHandler extends ChannelInboundHandlerAdapter {
+
+    /**
+     * Read and print the msg from channel.
+     * @param ctx
+     * @param msg
+     */
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        ByteBuf incoming = (ByteBuf) msg;
+        try {
+            while (incoming.isReadable()) {
+                System.out.print((char) incoming.readByte());
+                System.out.flush();
+            }
+        } finally {
+            // The msg object is an reference counting object.
+            ReferenceCountUtil.release(msg);
+        }
+    }
+
+    /**
+     * Catch exception, and close connections.
+     * @param ctx
+     * @param cause
+     */
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        // Close the connection when an exception is raised.
+        // TODO: log this, instead of printStackTrace()
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/broke/src/main/java/org/syyllab/broke/channel/handler/package-info.java
+++ b/broke/src/main/java/org/syyllab/broke/channel/handler/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package used for handler, for processing on channel.
+ */
+
+package org.syyllab.broke.channel.handler;

--- a/broke/src/main/java/org/syyllab/broke/channel/package-info.java
+++ b/broke/src/main/java/org/syyllab/broke/channel/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package used for dealing with channel, as a pipeline of processing.
+ */
+
+package org.syyllab.broke.channel;

--- a/broke/src/main/java/org/syyllab/broke/package-info.java
+++ b/broke/src/main/java/org/syyllab/broke/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The main package used for broke.
+ */
+
+package org.syyllab.broke;


### PR DESCRIPTION
add a simple case from netty userguide for scratching handlers and pipeline layout.

Execution:
```bash
# need to install nc (on OS X)
echo "Hello server!" | nc 127.0.0.1 8181
```

The basic packages format, currently. We'll have to refactor this after further development.
@allenlee820202 